### PR TITLE
Fetch all containers when trying to map container IP to container metadata

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -78,7 +78,7 @@ func (d *dockerContainerService) syncContainer(containerIP string, oldInfo docke
 func (d *dockerContainerService) syncContainers(now time.Time) {
 	log.Info("Synchronizing state with running docker containers")
 	apiContainers, err := d.docker.ListContainers(docker.ListContainersOptions{
-		All:    true,  // only running containers
+		All:    true,  // fetch all containers
 		Size:   false, // do not need size information
 		Limit:  0,     // all running containers
 		Since:  "",    // not applicable

--- a/docker.go
+++ b/docker.go
@@ -78,7 +78,7 @@ func (d *dockerContainerService) syncContainer(containerIP string, oldInfo docke
 func (d *dockerContainerService) syncContainers(now time.Time) {
 	log.Info("Synchronizing state with running docker containers")
 	apiContainers, err := d.docker.ListContainers(docker.ListContainersOptions{
-		All:    false, // only running containers
+		All:    true,  // only running containers
 		Size:   false, // do not need size information
 		Limit:  0,     // all running containers
 		Since:  "",    // not applicable

--- a/docker.go
+++ b/docker.go
@@ -106,6 +106,11 @@ func (d *dockerContainerService) syncContainers(now time.Time) {
 			continue
 		}
 
+		if !container.State.Running {
+			log.Info("Skipping non-running container: id=", apiContainer.ID, " status=", container.State.Status)
+			continue
+		}
+
 		var containerIPs []string
 		if container.NetworkSettings.IPAddress != "" {
 			containerIPs = append(containerIPs, container.NetworkSettings.IPAddress)


### PR DESCRIPTION
In the newer versions of Docker, there is a slight delay between when a container has started executing and when the Docker daemon API reports it as running.  This is breaking IAM credential lookups in the first few milliseconds after a container started - notably impacting the Indymaps service.

This is not a complete fix, but appears to help.  The metaproxy service does the following:
1.  Fetch all running containers
2.  Loop through the list and `inspect` each container to get metadata & IP address details
3.  Matches the calling container's IP to the container metadata
4.  The rest of its magic

This change fetches all containers, not just running containers, and then does the inspect.  The delay between fetching the list and doing the inspect appears to be "enough" to solve the underlying race condition.

Note that non-running containers are skipped. 